### PR TITLE
Set default UBID precision to 11

### DIFF
--- a/flask-app/utils/ubid.py
+++ b/flask-app/utils/ubid.py
@@ -10,7 +10,11 @@ from openlocationcode.openlocationcode import PAIR_CODE_LENGTH_
 from shapely.geometry import Point, Polygon
 
 
-def encode_ubid(geometry: Polygon, code_length: int = PAIR_CODE_LENGTH_) -> str:
+def encode_ubid(geometry: Polygon, code_length: int = 11) -> str:
+    """
+    Default code_length from openlocationcode.PAIR_CODE_LENGTH_ is 10, but we want additional
+    precision, so we set the default here to 11.
+    """
     min_longitude, min_latitude, max_longitude, max_latitude = geometry.bounds
     centroid = geometry.centroid
     ubid = encode(min_latitude, min_longitude, max_latitude, max_longitude, centroid.y, centroid.x, codeLength=code_length)

--- a/flask-app/utils/ubid.py
+++ b/flask-app/utils/ubid.py
@@ -6,7 +6,6 @@ See also https://github.com/SEED-platform/seed/blob/main/LICENSE.md
 
 from buildingid.code import decode, encode
 from geopandas import GeoDataFrame
-from openlocationcode.openlocationcode import PAIR_CODE_LENGTH_
 from shapely.geometry import Point, Polygon
 
 


### PR DESCRIPTION
In the `flask-app/utils/ubid.py` script, set the default code_length for the `encode_ubid` function to be 11. 

This overrides the default precision of 10 which is set by `openlocationcode.PAIR_CODE_LENGTH_`. 

Resolves issue #13